### PR TITLE
test: Make test log level configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,9 +269,26 @@ $
 ````
 
 ### Execute unit tests
-The project make extensive use of Mocha JavaScript unit test framework. You can run all unit tests at once:
+The project make extensive use of Mocha JavaScript unit test framework. You can run the tests as following:
 ````bash
+# Run all at once
 npm run test
+
+# Run the tests filtered by description. (You can also use -g for filtering by regex)
+npm run test -- -f 'StageHandler'
+
+# Run with more detailed logging level (default: debug)
+npm run test -- -f 'StageHandler' --noisy
+
+# Run with specified logging level
+npm run test -- -f 'StageHandler' --noisy verbose
+
+# Allowed log levels are:
+#
+# silly, input, verbose *, http, prompt, debug *, info *, data, help, warn *, error *
+#
+# * - effectivelly used in code.
+
 ````
 <details>
   <summary>Click to see: Example of unit tests output.</summary>
@@ -303,6 +320,8 @@ node:internal/dns/utils:74
 $
 ````  
 </details>
+
+> :warning: **NOTE** The logging level for the test runs is configured independently from the normal run of the service, which uses the `config.yaml` file. See [Configuration](#configuration).
 
 See [Documentation on mochajs.org](https://mochajs.org/) for more details on how to use **Mocha**.
 

--- a/src/stagehandler.ts
+++ b/src/stagehandler.ts
@@ -280,7 +280,7 @@ export class StageHandler {
 			reply.error = response.error;
 			res.status(STATUS_UNAUTHORIZED);
 			// eslint-disable-next-line no-magic-numbers
-			this.log.verbose(`Reply=\n${JSON.stringify(reply, null, 2)}, STATUS CODE: ${STATUS_UNAUTHORIZED}`);
+			this.log.debug(`Reply=\n${JSON.stringify(reply, null, 2)}, STATUS CODE: ${STATUS_UNAUTHORIZED}`);
 			res.json(reply);
 			return;
 		}

--- a/test/config.ts
+++ b/test/config.ts
@@ -17,10 +17,31 @@ limitations under the License.
 import { argv } from "process";
 import { Log } from "../src/log";
 import WhyRunning from "why-is-node-running";
-import "mocha";
+import { LoggingConfig } from "../src/config";
 
-if (!argv.includes("--noisy")) {
+const noisyFlag = '--noisy';
+const allowedLevels = ['silly','input','verbose','http','prompt','debug','info','data','help','warn','error'];
+
+// Configure logging level for the test run
+if ( !argv.includes(noisyFlag) ) {
+	// Silence the log, if no --noisy flag
 	Log.ForceSilent();
+} else {
+	// Otherwise check if custom level provided or use 'debug' by default
+	const customVal = argv[argv.indexOf(noisyFlag) + 1]; // We are not checking for index out of bounds, since 'undefined' is not a valid level!
+	const isProvided = allowedLevels.includes(customVal);
+	const levelToUse = isProvided ? customVal : 'debug';
+
+	// Construct simple logging config
+	const loggingCfg = {
+		console: levelToUse,
+		lineDateFormat: "MMM-D HH:mm:ss.SSS",
+		files: []
+	} as LoggingConfig;
+
+	// Configure the logger
+	new Log("Log").warn(`Setting log level to: ${levelToUse} (${ isProvided ? 'provided' : 'default' }). See ./test/config.ts for further details.`);
+	Log.Configure(loggingCfg);
 }
 
 after(() => {


### PR DESCRIPTION
- closes https://github.com/famedly/uia-proxy/issues/190
- log level for the test run is now configurable over --noisy <level> flag.