### PR TITLE
chore: update GitHub Action pins

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    uses: famedly/backend-build-workflows/.github/workflows/docker-backend.yml@main
+    uses: famedly/backend-build-workflows/.github/workflows/docker-backend.yml@fcc2ec82a725d5c4c9c6a8f19e8df101c178dcb6
     secrets: inherit
     with:
       name: uia-proxy


### PR DESCRIPTION
## Summary
- Pin all external GitHub Actions in workflows to current upstream default-branch commit SHAs.
- Includes actions discovered from every `uses:` entry in `.github/**/*.yml` and `.github/**/*.yaml`.

## Verification
- Commit is GPG-signed locally.
- CI on this PR should validate the updated action refs.